### PR TITLE
Name the gil_load thread for clarity

### DIFF
--- a/gil_load/gil_load.pyx
+++ b/gil_load/gil_load.pyx
@@ -573,7 +573,7 @@ def start(av_sample_interval=0.005, output_interval=5, output=None, reset_counts
 
     with lock:
         if monitoring_thread is None:
-            monitoring_thread = threading.Thread(target=_run)
+            monitoring_thread = threading.Thread(target=_run, name="gil_load")
             monitoring_thread.daemon = True
             monitoring_thread.start()
 


### PR DESCRIPTION
Thank you for this wonderful tool! Since people using this tool will be busy looking at the many threads of their application, it can be confusing to see an unnamed thread. 

I found myself investigating until I remembered that there wasn't a named thread for gil_load, and it was probably the unnamed thread I had in the list. 