### PR TITLE
Add Cython to build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel", "Cython"]  # PEP 508 specifications.


### PR DESCRIPTION
I have encountered issues while adding gil_load to my package's dependencies, as it requires Cython to be installed for setup.py to run successfully.
This PR should allow a single simple install with pip by specifying Cython in gil_load's [build dependencies](https://www.python.org/dev/peps/pep-0518/#id27).

Thanks for this great extension :)