### PR TITLE
Introduce a thread number reallocation table

### DIFF
--- a/gil_load/preload.c
+++ b/gil_load/preload.c
@@ -12,6 +12,11 @@
 static int (*mutex_lock_internal)(pthread_mutex_t *mutex);
 static int (*mutex_unlock_internal)(pthread_mutex_t *mutex);
 static int (*sem_wait_internal)(sem_t *sem);
+static void (*exit_internal)(void *retval);
+static int (*create_internal)(pthread_t *restrict thread,
+                                      const pthread_attr_t *restrict attr,
+                                      void *(*start_routine)(void *),
+                                      void *restrict arg);
 
 // Py2:
 static sem_t * GIL_acq_sem = NULL;
@@ -25,9 +30,16 @@ static int initialised = 0;
 // blocking waiting for the GIL.
 static int threads_waiting[MAX_THREADS_TRACKED];
 static pthread_t threads[MAX_THREADS_TRACKED];
+
+// Thread number reallocation table, as a circular buffer
+static int tnum_reallocation_table[MAX_THREADS_TRACKED];
+static size_t tnum_lpop_idx = 0;
+static size_t tnum_rpush_idx = 0;
+
 // how many threads we have seen. Possible larger than the number we are
 // tracking if it exceeds MAX_THREADS_TRACKED::
-static int n_threads_seen;
+static int n_threads_seen = 0;
+static int n_threads_tracked = 0;
 
 // A mutex for non-atomic operations on the above:
 static pthread_mutex_t threads_tracked_mutex;
@@ -39,26 +51,77 @@ static __thread int thread_number = -1;
 // The thread that most recently acquired the GIL:
 static int most_recently_acquired = -1;
 
+// Add a thread number (index in the threads/threads_waiting array) to the
+// reallocation table.
+static void mark_reallocatable_thread_num(int tnum){
+    if (tnum >= MAX_THREADS_TRACKED){
+        // Untracked thread
+        return;
+    }
+    if (tnum_rpush_idx - tnum_lpop_idx >= MAX_THREADS_TRACKED){
+        // reallocation table is full
+        return;
+    }
+    tnum_reallocation_table[tnum_rpush_idx % MAX_THREADS_TRACKED] = tnum;
+    tnum_rpush_idx++;
+}
+
+// True if there is at least one thread number in the reallocation table
+static inline int has_reallocatable_thread_num(){
+    return tnum_lpop_idx < tnum_rpush_idx;
+}
+
+// Get the next thread number from the reallocation table
+static inline int get_reallocatable_thread_num(){
+    int res = tnum_reallocation_table[tnum_lpop_idx % MAX_THREADS_TRACKED];
+    tnum_lpop_idx++;
+    return res;
+}
+
+// Allocate a thread number
+static int allocate_thread_number(){
+    int res;
+    if (has_reallocatable_thread_num()) {
+        res = get_reallocatable_thread_num();
+        // printf("Reusing thread #%d\n", res);
+    } else if (n_threads_tracked < MAX_THREADS_TRACKED){
+        res = n_threads_tracked;
+        n_threads_tracked++;
+        // printf("Tracking new thread #%d\n", res);
+    } else {
+        res = n_threads_seen;
+    }
+    n_threads_seen++;
+    return res;
+}
+
 void __attribute__ ((constructor)) init_gil_load(void);
 void init_gil_load(void){
     sem_wait_internal = dlsym(RTLD_NEXT, "sem_wait");
     mutex_lock_internal = dlsym(RTLD_NEXT, "pthread_mutex_lock");
     mutex_unlock_internal = dlsym(RTLD_NEXT, "pthread_mutex_unlock");
+    exit_internal = dlsym(RTLD_NEXT, "pthread_exit");
+    create_internal = dlsym(RTLD_NEXT, "pthread_create");
     pthread_mutex_init(&threads_tracked_mutex, NULL);
 }
 
 void register_new_thread(pthread_t thread){
     mutex_lock_internal(&threads_tracked_mutex);
-    thread_number = n_threads_seen;
-    n_threads_seen++;
+    thread_number = allocate_thread_number();
     if(thread_number < MAX_THREADS_TRACKED){
         threads[thread_number] = thread;
         threads_waiting[thread_number] = 0;
     }
     else{
-        fprintf(stderr, "gil_load warning: too many threads, not all will be tracked\n");
+        fprintf(stderr, "gil_load warning: too many active threads, not all will be tracked\n");
     }
     pthread_mutex_unlock(&threads_tracked_mutex);
+}
+
+void unregister_thread(){
+    mutex_lock_internal(&threads_tracked_mutex);
+    mark_reallocatable_thread_num(thread_number);
+    mutex_unlock_internal(&threads_tracked_mutex);
 }
 
 void mark_thread_waiting_for_gil(pthread_t thread){
@@ -123,6 +186,45 @@ int pthread_mutex_unlock(pthread_mutex_t *mutex){
     return ret;
 }
 
+void __attribute__((noreturn)) pthread_exit(void *retval);
+void pthread_exit(void *retval){
+    unregister_thread();
+    exit_internal(retval);
+    while (1);  // noreturn
+}
+
+struct thread_routine {
+    void *(*func)(void *arg);
+    void *arg;
+};
+
+void *thread_routine_wrapper(void *entrypoint)
+{
+    struct thread_routine *routine = (struct thread_routine *) entrypoint;
+    void *(*start_routine)(void *) = routine->func;
+    void *arg = routine->arg;
+    free(routine);
+
+    void *retval = start_routine(arg);
+    unregister_thread();
+    return retval;
+}
+
+int pthread_create(pthread_t *restrict thread,
+                   const pthread_attr_t *restrict attr,
+                   void *(*start_routine)(void *),
+                   void *restrict arg){
+    struct thread_routine *routine = calloc(1, sizeof(struct thread_routine));
+    if (! routine){
+        return -EAGAIN;
+    }
+
+    routine->func = start_routine;
+    routine->arg = arg;
+
+    return create_internal(thread, attr, thread_routine_wrapper, routine);
+}
+
 int set_initialised(void){
     initialised = 1;
     if (PY_MAJOR_VERSION == 3 && GIL_acq_mutex == NULL){
@@ -155,12 +257,7 @@ int begin_sample(void){
     // the mutex when it is done. We return the number of elements it is safe
     // to read from the array.
     mutex_lock_internal(&threads_tracked_mutex);
-    if (n_threads_seen < MAX_THREADS_TRACKED){
-        return n_threads_seen;
-    }
-    else{
-        return MAX_THREADS_TRACKED;
-    }
+    return n_threads_tracked;
 }
 
 void end_sample(void){

--- a/gil_load/preload.h
+++ b/gil_load/preload.h
@@ -1,6 +1,7 @@
 int set_initialised(void);
 pthread_t * get_threads_arr(void);
 int * get_threads_waiting_arr(void);
+int * get_threads_terminated_arr(void);
 int begin_sample(void);
 void end_sample(void);
 int get_most_recently_acquired(void);


### PR DESCRIPTION
Some applications or libraries can spawn many short-lived threads. Because the size of the thread tracking table is fixed (to 1024 elements), the available slots could quickly get exhausted, and gil_load will simply print `gil_load warning: too many threads, not all will be tracked`.

To work around this problem, we can detect when a thread dies, and mark its thread number as reusable. In such case, as long as there are not more than 1024 concurrent threads (running at the same time), they can all be tracked.

Example application:
```python
import threading
from time import sleep

import gil_load

THREADS_TO_SPAWN = 10_000

x = 1


def thread_function():
    """Thread function, expected to run for ~1s if no contention"""
    global x
    n = 100
    for i in range(n):
        # Let's create some GIL contention
        x = x ** 0.5
        x *= 2
        sleep(0.9/n)


gil_load.init()
gil_load.start()

threads = []
for i in range(THREADS_TO_SPAWN):
    if i % 1000 == 0:
        print(f"Spawning threads [{i // 1000}k/{THREADS_TO_SPAWN // 1000}k]...")
    if i % 10000 == 0:
        stats = gil_load.get()
        print(gil_load.format(stats))

    t = threading.Thread(target=thread_function, name=f"shortlived-{i}")
    threads.append(t)
    t.start()
    sleep(0.01)

print(f"Spawned {THREADS_TO_SPAWN} threads")

for i, t in enumerate(threads):
    t.join()

print("Joined all threads")
print(f"x = {x}")

gil_load.stop()
stats = gil_load.get()
print(gil_load.format(stats))
```